### PR TITLE
    Adding Observation Provider info into obs diag files used for obs AutoQC

### DIFF
--- a/src/gsi/setupq.f90
+++ b/src/gsi/setupq.f90
@@ -107,6 +107,9 @@ subroutine setupq(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
 !                              error (DOE) calculation to the namelist
 !                              level; they are now loaded by
 !                              aircraftinfo.
+!   2020-11-xx pondeca/morris - added observation provider/subprovider information in
+!                               diagonostic file, which is used in offline
+!                               observation quality control program for 3D-RTMA.
 !
 !
 !   input argument list:
@@ -165,6 +168,7 @@ subroutine setupq(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
   use rapidrefresh_cldsurf_mod, only: l_sfcobserror_ramp_q
   use rapidrefresh_cldsurf_mod, only: l_pbl_pseudo_surfobsq,pblh_ration,pps_press_incr, &
                                       i_use_2mq4b,l_closeobs,i_coastline
+  use rapidrefresh_cldsurf_mod, only:l_rtma3d
   use gsi_bundlemod, only : gsi_bundlegetpointer
   use gsi_metguess_mod, only : gsi_metguess_get,gsi_metguess_bundle
   use sparsearr, only: sparr2, new, size, writearray, fullarray
@@ -244,6 +248,7 @@ subroutine setupq(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
   character(8) station_id
   character(8),allocatable,dimension(:):: cdiagbuf,cdiagbufp
   character(8),allocatable,dimension(:):: cprvstg,csprvstg
+  character(8),allocatable,dimension(:):: cprvstgp,csprvstgp ! <-- provider info array for pseudo obs
   character(8) c_prvstg,c_sprvstg
   real(r_double) r_prvstg,r_sprvstg
 
@@ -367,7 +372,11 @@ subroutine setupq(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
      ioff0=21
      nreal=ioff0
      if (lobsdiagsave) nreal=nreal+4*miter+1
-     if (twodvar_regional) then; nreal=nreal+2; allocate(cprvstg(nobs),csprvstg(nobs)); endif
+     if (twodvar_regional .or. l_rtma3d) then
+       nreal=nreal+2                            ! account for idomsfc,izz
+       allocate(cprvstg(nobs),csprvstg(nobs))   ! obs provider info
+       if(l_pbl_pseudo_surfobsq) allocate(cprvstgp(nobs*3),csprvstgp(nobs*3)) ! obs provider info for pseudo obs
+       endif
      if (save_jacobian) then
        nnz   = 2                   ! number of non-zero elements in dH(x)/dx profile
        nind   = 1
@@ -889,11 +898,11 @@ subroutine setupq(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
                  if (err_adjst>tiny_r_kind) errinv_adjst = one/err_adjst
                  if (err_final>tiny_r_kind) errinv_final = one/err_final
 
-                 if(binary_diag) call contents_binary_diagp_()
+                 if(binary_diag) call contents_binary_diagp_(my_diag_pbl)
               else
                  iip=3*nobs
               endif
-              if(netcdf_diag) call contents_netcdf_diagp_()
+              if(netcdf_diag) call contents_netcdf_diagp_(my_diag_pbl)
            endif    !conv_diagsave .and. luse(i))
 
            prest = prest - pps_press_incr
@@ -914,20 +923,26 @@ subroutine setupq(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
   if(conv_diagsave) then
     if(netcdf_diag) call nc_diag_write
     if(binary_diag .and. ii>0)then
-       write(7)'  q',nchar,nreal,ii+iip,mype,ioff0
+!
+       write(7)'  q',nchar,nreal,ii+iip,mype,ioff0,iip
        if(l_pbl_pseudo_surfobsq .and. iip>0) then
           write(7)cdiagbuf(1:ii),cdiagbufp(1:iip),rdiagbuf(:,1:ii),rdiagbufp(:,1:iip)
-          deallocate(cdiagbufp,rdiagbufp)
        else
           write(7)cdiagbuf(1:ii),rdiagbuf(:,1:ii)
        endif
-       deallocate(cdiagbuf,rdiagbuf)
 
-       if (twodvar_regional) then
-          write(7)cprvstg(1:ii),csprvstg(1:ii)
+       if (twodvar_regional .or. l_rtma3d) then
+          if(l_pbl_pseudo_surfobsq .and. iip>0) then
+             write(7)cprvstg(1:ii),cprvstgp(1:iip),csprvstg(1:ii),csprvstgp(1:iip)
+          else
+             write(7)cprvstg(1:ii),csprvstg(1:ii)
+          endif
           deallocate(cprvstg,csprvstg)
+          if(l_pbl_pseudo_surfobsq) deallocate(cprvstgp,csprvstgp)
        endif
     endif
+    deallocate(cdiagbuf,rdiagbuf)
+    if(l_pbl_pseudo_surfobsq) deallocate(cdiagbufp,rdiagbufp)
   end if
 
 ! End of routine
@@ -1116,7 +1131,7 @@ subroutine setupq(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
            enddo
         endif
 
-        if (twodvar_regional) then
+        if (twodvar_regional .or. l_rtma3d) then
            ioff = ioff + 1
            rdiagbuf(ioff,ii) = data(idomsfc,i) ! dominate surface type
            ioff = ioff + 1
@@ -1133,12 +1148,14 @@ subroutine setupq(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
 
   end subroutine contents_binary_diag_
 
-  subroutine contents_binary_diagp_
+  subroutine contents_binary_diagp_(odiag)
+    type(obs_diag),pointer,intent(in):: odiag
 
         cdiagbufp(iip)    = station_id         ! station id
 
         rdiagbufp(1,iip)  = ictype(ikx)        ! observation type
-        rdiagbufp(2,iip)  = icsubtype(ikx)     ! observation subtype
+!        rdiagbufp(2,iip)  = icsubtype(ikx)     ! observation subtype
+        rdiagbufp(2,iip)  = -1                 ! observation subtype (-1 for pseudo obs)
             
         rdiagbufp(3,iip)  = data(ilate,i)      ! observation latitude (degrees)
         rdiagbufp(4,iip)  = data(ilone,i)      ! observation longitude (degrees)
@@ -1169,8 +1186,42 @@ subroutine setupq(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
         rdiagbufp(21,iip) = 1e+10_r_single     ! spread (filled in by EnKF)
 
         ioff=ioff0
+
+        if (lobsdiagsave) then
+           do jj=1,miter 
+              ioff=ioff+1 
+              if (odiag%muse(jj)) then
+                 rdiagbufp(ioff,iip) = one
+              else
+                 rdiagbufp(ioff,iip) = -one
+              endif
+           enddo
+           do jj=1,miter+1
+              ioff=ioff+1
+              rdiagbufp(ioff,iip) = odiag%nldepart(jj)
+           enddo
+           do jj=1,miter
+              ioff=ioff+1
+              rdiagbufp(ioff,iip) = odiag%tldepart(jj)
+           enddo
+           do jj=1,miter
+              ioff=ioff+1
+              rdiagbufp(ioff,iip) = odiag%obssen(jj)
+           enddo
+        endif
+
+        if (twodvar_regional .or. l_rtma3d) then
+           ioff = ioff + 1
+           rdiagbufp(ioff,iip) = -9999. !  data(idomsfc,i) ! dominate surface type
+           ioff = ioff + 1
+           rdiagbufp(ioff,iip) = -9999. !  data(izz,i)     ! model terrain at ob location
+           r_prvstg            = data(iprvd,i)
+           cprvstgp(iip)         = '88888888'    !c_prvstg        ! provider name
+           r_sprvstg           = data(isprvd,i)
+           csprvstgp(iip)        = '88888888'    !c_sprvstg       ! subprovider name
+        endif
         if (save_jacobian) then
-           call writearray(dhx_dx, rdiagbuf(ioff+1:nreal,ii))
+           call writearray(dhx_dx, rdiagbufp(ioff+1:nreal,iip))
            ioff = ioff + size(dhx_dx)
         endif
 
@@ -1224,7 +1275,7 @@ subroutine setupq(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
               call nc_diag_data2d("ObsDiagSave_obssen",   odiag%obssen   )             
            endif
 
-           if (twodvar_regional) then
+           if (twodvar_regional .or. l_rtma3d) then
               call nc_diag_metadata("Dominant_Sfc_Type", data(idomsfc,i)              )
               call nc_diag_metadata("Model_Terrain",     data(izz,i)                  )
               r_prvstg            = data(iprvd,i)
@@ -1240,14 +1291,17 @@ subroutine setupq(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
 
   end subroutine contents_netcdf_diag_
 
-  subroutine contents_netcdf_diagp_
+  subroutine contents_netcdf_diagp_(odiag)
+  type(obs_diag),pointer,intent(in):: odiag
 ! Observation class
   character(7),parameter     :: obsclass = '      q'
+  real(r_kind),dimension(miter) :: obsdiag_iuse
 
            call nc_diag_metadata("Station_ID",              station_id             )
            call nc_diag_metadata("Observation_Class",       obsclass               )
            call nc_diag_metadata("Observation_Type",        ictype(ikx)            )
-           call nc_diag_metadata("Observation_Subtype",     icsubtype(ikx)         )
+!          call nc_diag_metadata("Observation_Subtype",     icsubtype(ikx)         )
+           call nc_diag_metadata("Observation_Subtype",     -1                     )
            call nc_diag_metadata("Latitude",                sngl(data(ilate,i))    )
            call nc_diag_metadata("Longitude",               sngl(data(ilone,i))    )
            call nc_diag_metadata("Station_Elevation",       sngl(data(istnelv,i))  )
@@ -1272,6 +1326,31 @@ subroutine setupq(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
            call nc_diag_metadata("Obs_Minus_Forecast_unadjusted", sngl(ddiff)       )
            call nc_diag_metadata("Forecast_Saturation_Spec_Hum",  sngl(qsges)       )
 
+           if (lobsdiagsave) then
+              do jj=1,miter
+                 if (odiag%muse(jj)) then
+                       obsdiag_iuse(jj) =  one
+                 else
+                       obsdiag_iuse(jj) = -one
+                 endif
+              enddo
+
+              call nc_diag_data2d("ObsDiagSave_iuse",     obsdiag_iuse                             )
+              call nc_diag_data2d("ObsDiagSave_nldepart", odiag%nldepart )
+              call nc_diag_data2d("ObsDiagSave_tldepart", odiag%tldepart )
+              call nc_diag_data2d("ObsDiagSave_obssen",   odiag%obssen   )             
+           endif
+
+           if (twodvar_regional .or. l_rtma3d) then
+              call nc_diag_metadata("Dominant_Sfc_Type", data(idomsfc,i)              )
+              call nc_diag_metadata("Model_Terrain",     data(izz,i)                  )
+              r_prvstg            = data(iprvd,i)
+!             call nc_diag_metadata("Provider_Name",     c_prvstg                     )    
+              call nc_diag_metadata("Provider_Name",     "88888888"                   )    
+              r_sprvstg           = data(isprvd,i)
+!             call nc_diag_metadata("Subprovider_Name",  c_sprvstg                    )
+              call nc_diag_metadata("Subprovider_Name",  "88888888"                   )
+           endif
            if (save_jacobian) then
              call nc_diag_data2d("Observation_Operator_Jacobian_stind", dhx_dx%st_ind)
              call nc_diag_data2d("Observation_Operator_Jacobian_endind", dhx_dx%end_ind)

--- a/src/gsi/setupt.f90
+++ b/src/gsi/setupt.f90
@@ -69,7 +69,8 @@ subroutine setupt(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
   use converr, only: ptabl
   use rapidrefresh_cldsurf_mod, only: l_gsd_terrain_match_surftobs,l_sfcobserror_ramp_t
   use rapidrefresh_cldsurf_mod, only: l_pbl_pseudo_surfobst, pblh_ration,pps_press_incr
-  use rapidrefresh_cldsurf_mod, only: i_use_2mt4b,i_sfct_gross,l_closeobs,i_coastline       
+  use rapidrefresh_cldsurf_mod, only: i_use_2mt4b,i_sfct_gross,l_closeobs,i_coastline    
+  use rapidrefresh_cldsurf_mod, only: l_rtma3d   
 
   use aircraftinfo, only: npredt,predt,aircraft_t_bc_pof,aircraft_t_bc, &
        aircraft_t_bc_ext,ostats_t,rstats_t,upd_pred_t
@@ -220,6 +221,9 @@ subroutine setupt(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
 !                              observation error (DOE) calculation to
 !                              the namelist level; they are now
 !                              loaded by obsmod.
+!   2020-11-xx  pondeca/morris - added observation provider/subprovider information in
+!                                diagonostic file, which is used in offline
+!                                observation quality control program for 3D-RTMA.
 !
 ! !REMARKS:
 !   language: f90
@@ -295,6 +299,7 @@ subroutine setupt(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
   character(8) station_id
   character(8),allocatable,dimension(:):: cdiagbuf,cdiagbufp
   character(8),allocatable,dimension(:):: cprvstg,csprvstg
+  character(8),allocatable,dimension(:):: cprvstgp,csprvstgp ! <-- provider info array for pseudo obs
   character(8) c_prvstg,c_sprvstg
   real(r_double) r_prvstg,r_sprvstg
 
@@ -443,7 +448,11 @@ subroutine setupt(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
           nreal=nreal+npredt+2
      idia0=nreal
      if (lobsdiagsave) nreal=nreal+4*miter+1
-     if (twodvar_regional) then; nreal=nreal+2; allocate(cprvstg(nobs),csprvstg(nobs)); endif
+     if (twodvar_regional .or. l_rtma3d) then
+       nreal=nreal+2    ! account for idomsfc, izz used in diag for RTMA
+       allocate(cprvstg(nobs),csprvstg(nobs))      ! provider/subprovider info
+       if(l_pbl_pseudo_surfobst) allocate(cprvstgp(nobs*3),csprvstgp(nobs*3))  ! provider of pseudo obs 
+     endif
      if (save_jacobian) then
        nnz   = 2                   ! number of non-zero elements in dH(x)/dx profile
        nind   = 1
@@ -1206,12 +1215,12 @@ subroutine setupt(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
                  if (err_adjst>tiny_r_kind) errinv_adjst=one/err_adjst
                  if (err_final>tiny_r_kind) errinv_final=one/err_final
 
-                 if(binary_diag) call contents_binary_diagp_
+                 if(binary_diag) call contents_binary_diagp_(my_diag_pbl)
 
               else
                  iip=nobs
               endif
-              if(netcdf_diag) call contents_netcdf_diagp_
+              if(netcdf_diag) call contents_netcdf_diagp_(my_diag_pbl)
            end if
 
            prest = prest - pps_press_incr
@@ -1233,20 +1242,25 @@ subroutine setupt(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
   if(conv_diagsave)then
     if(netcdf_diag) call nc_diag_write
     if(binary_diag .and. ii>0)then
-       write(7)'  t',nchar,nreal,ii+iip,mype,idia0
+       write(7)'  t',nchar,nreal,ii+iip,mype,idia0,iip
        if(l_pbl_pseudo_surfobst .and. iip>0) then
           write(7)cdiagbuf(1:ii),cdiagbufp(1:iip),rdiagbuf(:,1:ii),rdiagbufp(:,1:iip)
-          deallocate(cdiagbufp,rdiagbufp)
        else
           write(7)cdiagbuf(1:ii),rdiagbuf(:,1:ii)
        endif
-       deallocate(cdiagbuf,rdiagbuf)
 
-       if (twodvar_regional) then
-          write(7)cprvstg(1:ii),csprvstg(1:ii)
+       if (twodvar_regional .or. l_rtma3d) then
+          if(l_pbl_pseudo_surfobst .and. iip>0) then
+             write(7)cprvstg(1:ii),cprvstgp(1:iip),csprvstg(1:ii),csprvstgp(1:iip)
+          else
+             write(7)cprvstg(1:ii),csprvstg(1:ii)
+          endif
           deallocate(cprvstg,csprvstg)
+          if(l_pbl_pseudo_surfobst) deallocate(cprvstgp,csprvstgp)
        endif
     end if
+    deallocate(cdiagbuf,rdiagbuf)
+    if(l_pbl_pseudo_surfobst) deallocate(cdiagbufp,rdiagbufp)
   end if
 
 
@@ -1523,7 +1537,7 @@ subroutine setupt(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
        enddo
     endif
 
-    if (twodvar_regional) then
+    if (twodvar_regional .or. l_rtma3d) then
        idia = idia + 1
        rdiagbuf(idia,ii) = data(idomsfc,i) ! dominate surface type
        idia = idia + 1
@@ -1541,12 +1555,14 @@ subroutine setupt(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
 
   end subroutine contents_binary_diag_
 
-  subroutine contents_binary_diagp_
+  subroutine contents_binary_diagp_(odiag)
+    type(obs_diag),pointer,intent(in):: odiag
 
       cdiagbufp(iip)    = station_id         ! station id
 
       rdiagbufp(1,iip)  = ictype(ikx)        ! observation type
-      rdiagbufp(2,iip)  = icsubtype(ikx)     ! observation subtype
+!      rdiagbufp(2,iip)  = icsubtype(ikx)     ! observation subtype
+      rdiagbufp(2,iip)  = -1                 ! observation subtype (-1 for pseudo obs)
             
       rdiagbufp(3,iip)  = data(ilate,i)      ! observation latitude (degrees)
       rdiagbufp(4,iip)  = data(ilone,i)      ! observation longitude (degrees)
@@ -1577,8 +1593,43 @@ subroutine setupt(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
      rdiagbufp(20,iip) = 1.e10_r_single     ! spread (filled in by EnKF)
 
      idia=idia0
+
+     if (lobsdiagsave) then
+        do jj=1,miter
+           idia=idia+1
+           if (odiag%muse(jj)) then
+              rdiagbufp(idia,iip) = one
+           else
+              rdiagbufp(idia,iip) = -one
+           endif
+        enddo
+        do jj=1,miter+1
+           idia=idia+1
+           rdiagbufp(idia,iip) = odiag%nldepart(jj)
+        enddo
+        do jj=1,miter
+           idia=idia+1
+           rdiagbufp(idia,iip) = odiag%tldepart(jj)
+        enddo
+        do jj=1,miter
+           idia=idia+1
+           rdiagbufp(idia,iip) = odiag%obssen(jj)
+        enddo
+     endif
+
+    if (twodvar_regional .or. l_rtma3d) then
+       idia = idia + 1
+       rdiagbufp(idia,iip) = -9999. ! data(idomsfc,i) ! dominate surface type
+       idia = idia + 1
+       rdiagbufp(idia,iip) = -9999. ! data(izz,i)     ! model terrain at observation location
+!      r_prvstg            = data(iprvd,i)
+       cprvstgp(iip)         = '88888888'    !c_prvstg        ! provider name
+!      r_sprvstg           = data(isprvd,i)
+       csprvstgp(iip)        = '88888888'    !c_sprvstg       ! subprovider name
+    endif
+
      if (save_jacobian) then
-        call writearray(dhx_dx, rdiagbuf(idia+1:nreal,ii))
+        call writearray(dhx_dx, rdiagbufp(idia+1:nreal,iip))
         idia = idia + size(dhx_dx)
      endif
 
@@ -1654,7 +1705,7 @@ subroutine setupt(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
        call nc_diag_data2d("ObsDiagSave_obssen",   odiag%obssen   )              
     endif
 
-    if (twodvar_regional) then
+    if (twodvar_regional .or. l_rtma3d) then
        call nc_diag_metadata("Dominant_Sfc_Type", data(idomsfc,i)              )
        call nc_diag_metadata("Model_Terrain",     data(izz,i)                  )
        r_prvstg            = data(iprvd,i)
@@ -1671,15 +1722,19 @@ subroutine setupt(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
 
   end subroutine contents_netcdf_diag_
 
-  subroutine contents_netcdf_diagp_
+  subroutine contents_netcdf_diagp_(odiag)
+    type(obs_diag),pointer,intent(in):: odiag
 ! Observation class
   character(7),parameter     :: obsclass = '      t'
   real(r_single),parameter::     missing = -9.99e9_r_single
 
+  real(r_kind),dimension(miter) :: obsdiag_iuse
+
     call nc_diag_metadata("Station_ID",              station_id             )
     call nc_diag_metadata("Observation_Class",       obsclass               )
     call nc_diag_metadata("Observation_Type",        ictype(ikx)            )
-    call nc_diag_metadata("Observation_Subtype",     icsubtype(ikx)         )
+!   call nc_diag_metadata("Observation_Subtype",     icsubtype(ikx)         )
+    call nc_diag_metadata("Observation_Subtype",     -1                     )
     call nc_diag_metadata("Latitude",                sngl(data(ilate,i))    )
     call nc_diag_metadata("Longitude",               sngl(data(ilone,i))    )
     call nc_diag_metadata("Station_Elevation",       sngl(data(istnelv,i))  )
@@ -1703,6 +1758,34 @@ subroutine setupt(obsLL,odiagLL,lunin,mype,bwork,awork,nele,nobs,is,conv_diagsav
     call nc_diag_metadata("Obs_Minus_Forecast_adjusted",   sngl(ddiff)      )
     call nc_diag_metadata("Obs_Minus_Forecast_unadjusted", sngl(ddiff)      )
 
+!----
+    if (lobsdiagsave) then
+       do jj=1,miter
+          if (odiag%muse(jj)) then
+             obsdiag_iuse(jj) =  one
+          else
+             obsdiag_iuse(jj) = -one
+          endif
+       enddo
+
+       call nc_diag_data2d("ObsDiagSave_iuse",     obsdiag_iuse                             )
+       call nc_diag_data2d("ObsDiagSave_nldepart", odiag%nldepart )
+       call nc_diag_data2d("ObsDiagSave_tldepart", odiag%tldepart )
+       call nc_diag_data2d("ObsDiagSave_obssen",   odiag%obssen   )              
+    endif
+
+    if (twodvar_regional .or. l_rtma3d) then
+       call nc_diag_metadata("Dominant_Sfc_Type", data(idomsfc,i)              )
+       call nc_diag_metadata("Model_Terrain",     data(izz,i)                  )
+!      r_prvstg            = data(iprvd,i)
+!      call nc_diag_metadata("Provider_Name",     c_prvstg                     )    
+       call nc_diag_metadata("Provider_Name",     "88888888"                    )    
+!      r_sprvstg           = data(isprvd,i)
+!      call nc_diag_metadata("Subprovider_Name",  c_sprvstg                    )
+       call nc_diag_metadata("Subprovider_Name",  "88888888"                   )
+    endif
+
+!----
     if (save_jacobian) then
        call nc_diag_data2d("Observation_Operator_Jacobian_stind", dhx_dx%st_ind)
        call nc_diag_data2d("Observation_Operator_Jacobian_endind", dhx_dx%end_ind)

--- a/ush/build.comgsi_wcoss_d
+++ b/ush/build.comgsi_wcoss_d
@@ -1,0 +1,162 @@
+#!/bin/sh
+# common modules to compile GSI/EnKF:
+#   Jet:      source /home/rtrr/PARM_EXEC/modulefiles/modulefile.jet.GSI_UPP_WRF
+#   Theia:    source /home/rtrr/PARM_EXEC/modulefiles/modulefile.theia.GSI_UPP_WRF
+#   Cheyenne: source /glade/p/ral/jntp/gge/modulefiles/modulefile.cheyenne.GSI_UPP_WRF
+#
+#  build commands:
+#    cmake -DENKF_MODE=WRF -DBUILD_CORELIBS=ON -DBUILD_GSDCLOUD_ARW=ON path_to_GSI
+#    cmake -DENKF_MODE=WRF -DBUILD_CORELIBS=ON -DBUILD_GSDCLOUD_ARW=ON -DBUILD_UTIL_COM=ON -DBUILD_ENKF_PREPROCESS_ARW=ON path_to_GSI"
+#    (for global: cmake -D-DENKF_MODE=GFS -DBUILD_CORELIBS=ON path_to_GSI)
+#    make -j8
+#
+
+dir_root=$(pwd)
+
+################# Hera ####################
+if [[ "`grep -i "hera" /etc/hosts | head -n1`" != "" ]] ; then
+    source /etc/profile.d/modules.sh
+    modulefile="/home/rtrr/PARM_EXEC/modulefiles/modulefile.hera.GSI_UPP_WRF"
+    NCEPLIBS="/scratch1/BMC/comgsi/precompiled/NCEPLIBS/b_intel18.0.5.274_impi2018.0.4/install"
+    GSILIBS="/scratch1/BMC/comgsi/precompiled/GSILIBS/b_intel18.0.5.274_impi2018.0.4"
+
+################# Jet ####################
+elif [[ -d /jetmon ]] ; then
+    source /etc/profile.d/modules.sh
+    modulefile="/home/rtrr/PARM_EXEC/modulefiles/modulefile.jet.GSI_UPP_WRF"
+    NCEPLIBS="/lfs4/BMC/wrfruc/gge/precompiled/NCEPLIBS/b_intel18.0.5.274_impi2018.4.274/install"
+    GSILIBS="/lfs4/BMC/wrfruc/gge/precompiled/GSILIBS/b_intel18.0.5.274_impi2018.4.274"
+
+################# Cheyenne ####################
+elif [[ -d /glade ]] ; then
+    source /etc/profile.d/modules.sh
+    modulefile="/glade/p/ral/jntp/gge/modulefiles/modulefile.cheyenne.GSI_UPP_WRF"
+    NCEPLIBS="/glade/p/ral/jntp/gge/precompiled/NCEPLIBS/b_intel18.0.5_impi2018.4.274/install"
+    GSILIBS="/glade/p/ral/jntp/gge/precompiled/GSILIBS/b_intel18.0.5_impi2018.4.274"
+    #modulefile="/glade/p/ral/jntp/gge/precompiled/NCEPLIBS/modulefile.cheyenne.GSI_UPP_WRF.gnu"
+    #NCEPLIBS="/glade/p/ral/jntp/gge/precompiled/NCEPLIBS/b_gnu8.3.0_openmpi3.1.4/install"
+    #GSILIBS="/glade/p/ral/jntp/gge/precompiled/GSILIBS/b_gnu8.3.0_openmpi3.1.4/"
+
+################# Orion ####################
+elif [[ -d /work/noaa ]] ; then  ### orion
+    modulefile="/home/gge/modulefiles/modulefile.orion.GSI_UPP_WRF"
+    NCEPLIBS="/work/noaa/wrfruc/gge/precompiled/NCEPLIBS/b_intel2018.4_impi2018.4/install"
+    GSILIBS="/work/noaa/wrfruc/gge/precompiled/GSILIBS/b_intel2018.4_impi2018.4"
+
+################# WCOSS-dell ####################
+elif [[ -d /ioddev_dell ]]; then
+    module purge
+    . $MODULESHOME/init/sh
+    target=wcoss_d
+    modulefile=$dir_root/modulefiles/modulefile.ProdGSI.${target}
+    LIBDIR_USER=/u/Gang.Zhao/local
+    echo " >>>>>>> on machine WCOSS-Dell <<<<<<< "
+
+################# Generic ####################
+else
+    echo -e "\nunknown machine"
+    echo "Please modify build.comgsi at this location"
+    echo "to load required modules and setup NCEPLIBS and GSILIBS"
+    ##follow the above examples and delete the following "exit 9" to go forward
+    exit 9
+    source /etc/profile.d/modules.sh
+    modulefile="/my/modulefile.me.GSI_UPP_WRF"
+    NCEPLIBS="/my/NCEPLIBS/b_intel18.0.5_impi2018.4.274/install"
+    GSILIBS="/my/GSILIBS/b_intel18.0.5_impi2018.4.274/"
+fi
+
+if [ ! -f $modulefile ]; then
+    echo "modulefiles $modulefile does not exist"
+    exit 10
+fi
+source $modulefile
+
+## if NETCDF4 is set to 0 or 1, unset it
+if [[ "$NETCDF4" == "1" ]] || [[ "$NETCDF4" == "0" ]]; then
+  unset NETCDF4
+fi
+
+if [ "$target" = "wcoss_d" ] ; then
+    echo " ----> on WCOSS-Dell: using EMC pre-installed NCEPLIBS. "
+    echo "                      but using wrflib user installed, since it is NOT included in NCEPLIBS yet."
+    export GSIWRF_LIB=${LIBDIR_USER}/lib/libWRFLIB.a
+    if [ ! -f ${GSIWRF_LIB} ] ; then
+      echo "  ERROR! ERROR! MISSING WRFLIB which is required for compiling GSI executables ... ABORT! "
+      echo "  PLEASE FIND WRFLIB USED FOR GSI AND DEFINE ENV VARIABLE GSIWRF_LIB WITH IT.  NOW ABORT! "
+      exit 1
+    fi
+else
+    export BACIO_LIB4=${NCEPLIBS}/lib/libbacio_4.a
+#    export  BUFR_LIBd=${NCEPLIBS}/lib/libbufr_d.a
+    export  BUFR_LIBd=${GSILIBS}/lib/libbufr_v.a
+    export GSIWRF_LIB=${GSILIBS}/lib/libWRFLIB.a
+    export   CRTM_LIB=${NCEPLIBS}/lib/libcrtm.a
+    export   CRTM_INC=${NCEPLIBS}/include
+    export NEMSIO_LIB=${NCEPLIBS}/lib/libnemsio.a
+    export NEMSIO_INC=${NCEPLIBS}/include
+    export SFCIO_LIB4=${NCEPLIBS}/lib/libsfcio_4.a
+    export SFCIO_INC4=${NCEPLIBS}/include_4
+    export SIGIO_LIB4=${NCEPLIBS}/lib/libsigio_4.a
+    export SIGIO_INC4=${NCEPLIBS}/include_4
+    export    SP_LIBd=${NCEPLIBS}/lib/libsp_d.a
+    export    SP_LIB4=${NCEPLIBS}/lib/libsp_4.a
+    export W3EMC_LIBd=${NCEPLIBS}/lib/libw3emc_d.a
+    export W3EMC_LIB4=${NCEPLIBS}/lib/libw3emc_4.a
+    export W3EMC_INCd=${NCEPLIBS}/include_d
+    export W3EMC_INC4=${NCEPLIBS}/include_4
+    export W3NCO_LIBd=${NCEPLIBS}/lib/libw3nco_d.a
+    export W3NCO_LIB4=${NCEPLIBS}/lib/libw3nco_4.a
+    export    IP_LIBd=${NCEPLIBS}/lib/libip_d.a
+    export    IP_LIB4=${NCEPLIBS}/lib/libip_4.a
+fi
+
+set -x
+rm -rf $dir_root/build
+mkdir -p $dir_root/build
+cd $dir_root/build
+set +x
+
+
+echo "compiled at the node: $(hostname)" >> output.log
+module list >> output.log 2>&1
+module list
+echo -e "\nThe branch name:" >> output.log
+git branch | grep "*"  >> output.log
+echo -e "\nThe commit ID:" >> output.log
+git log -1 | head -n1 >> output.log
+echo -e "\ngit status:" >> output.log
+git status >> output.log
+echo -e "\nCompiling commands:" >> output.log
+if [[ ${target} == "wcoss_d" ]] ; then
+#  echo "     on WCOSS-Dell: SET DBUILD_CORELIBS=OFF .." >> output.log
+#  echo "  cmake -DENKF_MODE=WRF -DBUILD_CORELIBS=OFF -DBUILD_GSDCLOUD_ARW=ON -DBUILD_ENKF_PREPROCESS_ARW=ON -DBUILD_UTIL_COM=ON -Wno-dev .." >> output.log
+#  cmake -DENKF_MODE=WRF -DBUILD_CORELIBS=OFF -DBUILD_GSDCLOUD_ARW=ON -DBUILD_ENKF_PREPROCESS_ARW=ON -DBUILD_UTIL_COM=ON -Wno-dev ..  2>&1  | tee output.cmake
+  echo "     on WCOSS-Dell: SET DBUILD_CORELIBS=ON .." >> output.log
+  echo "  cmake -DENKF_MODE=WRF -DBUILD_CORELIBS=ON -DBUILD_GSDCLOUD_ARW=ON -DBUILD_ENKF_PREPROCESS_ARW=ON -DBUILD_UTIL_COM=ON -Wno-dev .." >> output.log
+  cmake -DENKF_MODE=WRF -DBUILD_CORELIBS=ON -DBUILD_GSDCLOUD_ARW=ON -DBUILD_ENKF_PREPROCESS_ARW=ON -DBUILD_UTIL_COM=ON -Wno-dev ..  2>&1  | tee output.cmake
+  echo "  make -j8" >> output.log
+  cat output.log
+  make VERBOSE=1 -j 8 2>&1 | tee output.compile
+else 
+  echo "  cmake -DENKF_MODE=WRF -DBUILD_CORELIBS=ON -DBUILD_GSDCLOUD_ARW=ON -DBUILD_ENKF_PREPROCESS_ARW=ON -DBUILD_UTIL_COM=ON -Wno-dev .." >> output.log
+  echo "  make -j8" >> output.log
+  cat output.log
+  cmake -DENKF_MODE=WRF -DBUILD_CORELIBS=ON -DBUILD_GSDCLOUD_ARW=ON -DBUILD_ENKF_PREPROCESS_ARW=ON -DBUILD_UTIL_COM=ON -Wno-dev ..  2>&1  | tee output.cmake
+  make -j 8 2>&1 | tee output.compile
+fi
+
+
+###aftermath
+commitID=`git log -1 | head -n1 |cut -c8-15`
+repoName=`git config --get remote.origin.url | cut -d: -f2`
+repoName=${repoName//\//:}
+datestamp=`date +%Y%m%d`
+cd bin
+ln -sf gsi.x gsi.x_${repoName}_${datestamp}_${commitID}
+ln -sf enkf_wrf.x enkf_wrf.x_${repoName}_${datestamp}_${commitID}
+ln -sf enspreproc.x enspreproc.x_${repoName}_${datestamp}_${commitID}
+###mv $dir_root/build $dir_root/build_$commitID
+
+echo -e "\n\nAll build results are at ./build/ \n\n"
+
+exit

--- a/util/Analysis_Utilities/read_diag/CMakeLists.txt
+++ b/util/Analysis_Utilities/read_diag/CMakeLists.txt
@@ -11,3 +11,8 @@ cmake_minimum_required(VERSION 2.6)
   set_target_properties( read_diag_rad.x PROPERTIES COMPILE_FLAGS ${UTIL_COM_Fortran_FLAGS} )
   target_link_libraries( read_diag_rad.x ${GSISHAREDLIB} ${GSILIB} ${GSISHAREDLIB} )
   add_dependencies(read_diag_rad.x ${GSILIB} )
+
+  add_executable(read_diag_conv_3drtma.x  read_diag_conv_3drtma.f90 )
+  set_target_properties( read_diag_conv_3drtma.x PROPERTIES COMPILE_FLAGS ${UTIL_COM_Fortran_FLAGS} )
+  target_link_libraries( read_diag_conv_3drtma.x ${GSISHAREDLIB} ${GSILIB} ${GSISHAREDLIB} )
+  add_dependencies(read_diag_conv_3drtma.x ${GSILIB} )

--- a/util/Analysis_Utilities/read_diag/read_diag_conv_3drtma.f90
+++ b/util/Analysis_Utilities/read_diag/read_diag_conv_3drtma.f90
@@ -1,0 +1,272 @@
+PROGRAM read_diag_conv
+!
+!  This program is to show how to 
+!  read GSI diagnositic file for conventional data, which are
+!  generated from subroutine:
+!      setupps.f90
+!      setupt.f90
+!      setupq.f90
+!      setuppw.f90
+!      setupuv.f90
+!      setupsst.f90
+!      setupgps.f90
+!
+!  For example in setupt.f90:
+!      the arrary contents disgnosis information is rdiagbuf.
+!        cdiagbuf(ii)       ! station id
+!        rdiagbuf(1,ii)     ! observation type
+!        rdiagbuf(2,ii)     ! observation subtype
+!        rdiagbuf(3,ii)     ! observation latitude (degrees)
+!        rdiagbuf(4,ii)     ! observation longitude (degrees)
+!        rdiagbuf(5,ii)     ! station elevation (meters)
+!        rdiagbuf(6,ii)     ! observation pressure (hPa)
+!        rdiagbuf(7,ii)     ! observation height (meters)
+!        rdiagbuf(8,ii)     ! obs time (hours relative to analysis time)
+!        rdiagbuf(9,ii)     ! input prepbufr qc or event mark
+!        rdiagbuf(10,ii)    ! setup qc or event mark (currently qtflg only)
+!        rdiagbuf(11,ii)    ! read_prepbufr data usage flag
+!        rdiagbuf(12,ii)    ! analysis usage flag (1=use, -1=not used)
+!        rdiagbuf(13,ii)    ! nonlinear qc relative weight
+!        rdiagbuf(14,ii)    ! prepbufr inverse obs error (K**-1)
+!        rdiagbuf(15,ii)    ! read_prepbufr inverse obs error (K**-1)
+!        rdiagbuf(16,ii)    ! final inverse observation error (K**-1)
+!        rdiagbuf(17,ii)    ! temperature observation (K)
+!        rdiagbuf(18,ii)    ! obs-ges used in analysis (K)
+!        rdiagbuf(19,ii)    ! obs-ges w/o bias correction (K) (future slot)
+!
+!  It is written out as:
+!     write(7)'  t',nchar,nreal,ii,mype
+!     write(7)cdiagbuf(1:ii),rdiagbuf(:,1:ii)
+!
+
+ use kinds, only: r_kind,r_single,i_kind
+
+  implicit none
+
+! real(r_kind) tiny_r_kind
+!
+! read in variables
+!
+  character(8),allocatable,dimension(:):: cdiagbuf,cprvstg,csprvstg
+  character(8)::cprovider,csubprovider
+  real(r_single),allocatable,dimension(:,:)::rdiagbuf
+  integer(4) nchar,nreal,ii,mype
+  integer(4) idate
+!
+!  namelist files
+!
+  character(180) :: infilename        ! file from GSI running directory
+  character(180) :: outfilename       ! file name saving results
+  logical        :: dump_pseudo_obs_too !if true write out pseudo obs as well
+  namelist/iosetup/ infilename, outfilename, dump_pseudo_obs_too 
+!
+! output variables
+!
+  character(len=3)  :: var
+  real(r_single) :: rlat,rlon,rprs,rhgt,robs1,rdpt1,robs2,rdpt2,ruse,rerr
+  real(r_single) :: rdhr,iusev,ddiff
+  character(8) :: stationID
+  integer(i_kind) :: itype,iuse
+  integer(i_kind) :: isubtype,isubtype0
+!
+!  misc.
+!
+  character ::  ch
+  integer(i_kind) :: i,j,k,ios
+  integer(i_kind) :: ic, iflg
+
+  logical fexist
+
+!
+  data infilename /'diag_conv.dat'/
+  data outfilename /'diag_results'/
+  data dump_pseudo_obs_too /.false./
+
+  inquire(file='namelist.conv',exist=fexist)
+  if(fexist) then
+     open(11,file='namelist.conv')
+      read(11,iosetup)
+     close(11)
+  endif
+!
+  open(42, file=trim(outfilename),IOSTAT=ios)
+  if(ios > 0 ) then
+       write(*,*) ' cannot open file ', trim(outfilename)
+       stop 123
+  else
+       write(*,*) ' open file ', trim(outfilename)
+  endif
+!
+  OPEN (17,FILE=trim(infilename),STATUS='OLD',IOSTAT=ios,ACCESS='SEQUENTIAL',  &
+             FORM='UNFORMATTED')
+     if(ios > 0 ) then
+       write(*,*) ' file is unavailabe: ', trim(infilename)
+       stop 123
+     endif
+
+     read(17, ERR=999) idate
+     write(*,*) 'process date: ',idate
+100  continue
+     read(17, ERR=999,end=110) var, nchar,nreal,ii,mype
+     write(*,*) var, nchar,nreal,ii,mype
+     if (ii > 0) then
+          allocate(cdiagbuf(ii),rdiagbuf(nreal,ii),cprvstg(ii),csprvstg(ii))
+          read(17,ERR=999,end=110) cdiagbuf, rdiagbuf
+          cprvstg='XXXXXXXX' 
+          csprvstg='XXXXXXXX'
+          if (var(1:3)=='  t' .or. var(1:3)=='  q' .or. var(2:3)=='ps' .or. &
+              var(2:3)=='uv'  .or. var(1:3)=='spd') read(17)cprvstg,csprvstg
+          do i=1,ii
+             cprovider=cprvstg(i)
+             csubprovider=csprvstg(i)
+             itype=rdiagbuf(1,i)    ! observation type
+             isubtype=rdiagbuf(2,i) ! observation subtype
+             rlat=rdiagbuf(3,i)     ! observation latitude (degrees)
+             rlon=rdiagbuf(4,i)     ! observation longitude (degrees)
+             rprs=rdiagbuf(6,i)     ! observation pressure (hPa)
+             rhgt=rdiagbuf(7,i)     ! observation height (meters)
+             rdhr=rdiagbuf(8,i)     ! obs time (hours relative to analysis time)
+             iuse=int(rdiagbuf(12,i))    ! analysis usage flag (1=use, -1=monitoring ) 
+             iusev=int(rdiagbuf(11,i))    ! analysis usage flag ( value ) 
+             ddiff=rdiagbuf(18,i)   ! obs-ges used in analysis (K)
+             rerr = 0._r_single
+             if (rdiagbuf(16,i) > 1.0E-12_r_single) then   ! final inverse observation error (K**-1)
+               rerr = 1.0/rdiagbuf(16,i)
+             else
+               rerr = 0._r_single
+             end if
+             robs1=rdiagbuf(17,i)    !  observation (K)
+             rdpt1=rdiagbuf(18,i)    !  obs-ges used in analysis 
+
+! get station ID
+             stationID = cdiagbuf(i)
+!           Remove odd spaces in the station, provider, and subprovider names
+             iflg = 0
+             do ic=8,1,-1
+              ch = stationID(ic:ic)
+              if (ch > ' ' .and. ch <= 'z') then
+                iflg = 1
+              else
+                 stationID(ic:ic) = ' '
+              end if
+              if (ch == ' '  .and. iflg == 1) then
+                 stationID(ic:ic) = '_'
+              endif 
+             enddo
+
+             iflg = 0
+             do ic=8,1,-1
+              ch = cprovider(ic:ic)
+              if (ch > ' ' .and. ch <= 'z') then
+                iflg = 1
+              else
+                 cprovider(ic:ic) = ' '
+              end if
+              if (ch == ' '  .and. iflg == 1) then
+                 cprovider(ic:ic) = '_'
+              endif
+             enddo
+
+             iflg = 0
+             do ic=8,1,-1
+              ch = csubprovider(ic:ic)
+              if (ch > ' ' .and. ch <= 'z') then
+                iflg = 1
+              else
+                 csubprovider(ic:ic) = ' '
+              end if
+              if (ch == ' '  .and. iflg == 1) then
+                 csubprovider(ic:ic) = '_'
+              endif
+             enddo
+
+
+
+
+!
+!   When the data is q, unit convert kg/kg -> g/kg **/
+             if (var == "  q") then
+                robs1 = robs1 * 1000.0
+                rdpt1 = rdpt1 * 1000.0
+                rerr = rerr * 1000.0
+                ddiff = ddiff * 1000.0
+             end if
+!   When the data is pw, replase the rprs to -999.0 **/
+             if (var == " pw") rprs=-999.0
+!
+             if(robs1 > 1.0e8) then
+               robs1=-99999.9
+               ddiff=-99999.9
+             endif
+         if (cprovider(1:4)=='B7Hv' .or. cprovider(5:8)=='vH7B') then !this provider name comes with strange characters
+             cprovider(1:4)='B7Hv'
+             cprovider(5:8)='   '
+         endif
+
+         if (csubprovider(1:4)=='B7Hv' .or. csubprovider(5:8)=='vH7B') then
+             csubprovider(1:4)='B7Hv'
+             csubprovider(5:8)='   '
+         endif
+
+         if (itype==154 .and. trim(adjustl(var))=='tca') then
+             stationID='GOESSKY'
+             cprovider='GOESSKY'
+             csubprovider='GOESSKY'
+         end if
+
+         if (trim(cprovider)=='') cprovider='EMPTY'
+         if (trim(csubprovider)=='') csubprovider='EMPTY'
+
+         ! If we have ceiling or total cloud amount obs less than 0, set to
+         ! missing
+         if ((trim(adjustl(var))=="tca" .or. trim(adjustl(var))=="cei" .or.   &
+              trim(adjustl(var))=="vis" .or. trim(adjustl(var))=="gst") .and. &
+              robs1 < 0.) then
+           robs1=0.10000E+10
+           ddiff=0.10000E+10
+         end if
+
+         if (dump_pseudo_obs_too) then 
+            isubtype0=0
+          else
+            isubtype0=isubtype
+         endif
+!
+!  write out result for one variable on one pitch
+             if (var .ne. " uv" .and. isubtype0 >=0) then
+                !write (42,'(A3," @ ",A8," : ",I3,F10.2,F8.2,F8.2,F8.2,I5,2F10.2)') &
+                !   var,stationID,itype,rdhr,rlat,rlon,rprs,iuse,robs1,ddiff
+                write (42,'(A3,1x,A8,1x,A8,1x,A8,1x,I3,1x,F10.2,F8.2,F8.2,2F20.5,I5,2E15.5,1x,"NaN  NaN   ",E15.5,F10.3)') &
+                   var,stationID,cprovider,csubprovider,itype,rdhr,rlat,rlon,rprs,rhgt,iuse,robs1,ddiff,rerr,iusev
+
+             else if (var .eq. " uv" .and. isubtype0 >=0 ) then
+!  ** When the data is uv, additional output is needed **/
+                robs2=rdiagbuf(20,i)
+                rdpt2=rdiagbuf(21,i)
+                !write (42,'(A3," @ ",A8," : ",I3,F10.2,F8.2,F8.2,F8.2,I5,4F10.2)') &
+                !   var,stationID,itype,rdhr,rlat,rlon,rprs,iuse,robs1,ddiff,robs2,rdpt2
+                write (42,'(A3,1x,A8,1x,A8,1x,A8,1x,I3,1x,F10.2,F8.2,F8.2,2F20.5,I5,4E15.5,1x,E15.5,F10.3)') &
+                   var,stationID,cprovider,csubprovider,itype,rdhr,rlat,rlon,rprs,rhgt,iuse,robs1,ddiff,robs2,rdpt2,rerr,iusev
+             endif
+
+
+
+          enddo   ! i  end for one station
+
+          deallocate(cdiagbuf,rdiagbuf)
+          deallocate(cprvstg,csprvstg)
+     else
+        read(17)
+     endif
+     goto 100  ! goto another variable
+110  continue
+
+    close(17)
+    close(42)
+
+  STOP 9999
+
+999    PRINT *,'error read in diag file'
+      stop 1234
+
+END PROGRAM read_diag_conv


### PR DESCRIPTION
    ps/q/t/w/spd, to include the observation provider and
    sub-provider information into the diag files, which
    will be used in read_diag_conv_3drtma for auto-QC.

    Also adding a new spcific code read_diag_conv_3drtma.f90
    under read_diag to read the osb-diag file including
    the obs provider information for auto-qc.

    Adding a building script under ush for WCOSS/Dell machines.